### PR TITLE
JSON improvements

### DIFF
--- a/src/Response/ImmutableObjectModificationException.php
+++ b/src/Response/ImmutableObjectModificationException.php
@@ -1,0 +1,6 @@
+<?php
+namespace Gt\Fetch\Response;
+
+use Gt\Fetch\FetchException;
+
+class ImmutableObjectModificationException extends FetchException {}

--- a/src/Response/Json.php
+++ b/src/Response/Json.php
@@ -32,6 +32,10 @@ class Json extends StdClass implements ArrayAccess, Iterator {
 
 	/** @link https://php.net/manual/en/arrayaccess.offsetget.php */
 	public function offsetGet($offset) {
+		if(is_array($this->jsonObject)) {
+			return $this->jsonObject[$offset];
+		}
+
 		return $this->jsonObject->$offset;
 	}
 

--- a/src/Response/Json.php
+++ b/src/Response/Json.php
@@ -2,6 +2,7 @@
 namespace Gt\Fetch\Response;
 
 use ArrayAccess;
+use DateTime;
 use Iterator;
 use StdClass;
 
@@ -44,11 +45,11 @@ class Json extends StdClass implements ArrayAccess, Iterator {
 
 	/** @link https://php.net/manual/en/arrayaccess.offsetget.php */
 	public function offsetGet($offset) {
-		if(is_array($this->jsonObject)) {
+		if(is_array($this->jsonObject) && isset($this->jsonObject[0])) {
 			return $this->jsonObject[$offset];
 		}
 
-		return $this->iteratorProperties[$offset];
+		return $this->iteratorProperties[$offset] ?? null;
 	}
 
 	/** @link https://php.net/manual/en/arrayaccess.offsetset.php */
@@ -102,6 +103,51 @@ class Json extends StdClass implements ArrayAccess, Iterator {
 	/** @link https://php.net/manual/en/iterator.rewind.php */
 	public function rewind():void {
 		$this->iteratorKey = 0;
+	}
+
+	public function getBool(string $key):?bool {
+		$value = $this->offsetGet($key);
+		if(is_null($value)) {
+			return null;
+		}
+
+		return (bool)$value;
+	}
+
+	public function getString(string $key):?string {
+		$value = $this->offsetGet($key);
+		if(is_null($value)) {
+			return null;
+		}
+
+		return (string)$value;
+	}
+
+	public function getInt(string $key):?int {
+		$value = $this->offsetGet($key);
+		if(is_null($value)) {
+			return null;
+		}
+
+		return (int)$value;
+	}
+
+	public function getFloat(string $key):?float {
+		$value = $this->offsetGet($key);
+		if(is_null($value)) {
+			return null;
+		}
+
+		return (float)$value;
+	}
+
+	public function getDateTime(string $key):?DateTime {
+		$value = $this->offsetGet($key);
+		if(is_null($value)) {
+			return null;
+		}
+
+		return new DateTime($value);
 	}
 
 	private function setPropertiesRecursive():void {

--- a/src/Response/Json.php
+++ b/src/Response/Json.php
@@ -22,12 +22,24 @@ class Json extends StdClass implements ArrayAccess, Iterator {
 	}
 
 	public function __get(string $key) {
-		return $this->jsonObject->$key;
+		return $this->offsetGet($key);
+	}
+
+	public function __set(string $key, $value) {
+		$this->offsetSet($key, $value);
+	}
+
+	public function __unset(string $key) {
+		$this->offsetUnset($key);
+	}
+
+	public function __isset(string $key):bool {
+		return $this->offsetExists($key);
 	}
 
 	/** @link https://php.net/manual/en/arrayaccess.offsetexists.php */
 	public function offsetExists($offset):bool {
-		return isset($this->jsonObject[$offset]);
+		return isset($this->iteratorProperties[$offset]);
 	}
 
 	/** @link https://php.net/manual/en/arrayaccess.offsetget.php */
@@ -36,17 +48,17 @@ class Json extends StdClass implements ArrayAccess, Iterator {
 			return $this->jsonObject[$offset];
 		}
 
-		return $this->jsonObject->$offset;
+		return $this->iteratorProperties[$offset];
 	}
 
 	/** @link https://php.net/manual/en/arrayaccess.offsetset.php */
 	public function offsetSet($offset, $value):void {
-		$this->jsonObject->$offset = $value;
+		throw new ImmutableObjectModificationException();
 	}
 
 	/** @link https://php.net/manual/en/arrayaccess.offsetunset.php */
 	public function offsetUnset($offset):void {
-		unset($this->jsonObject->$offset);
+		throw new ImmutableObjectModificationException();
 	}
 
 	/** @link https://php.net/manual/en/iterator.current.php */

--- a/src/Response/Json.php
+++ b/src/Response/Json.php
@@ -9,19 +9,16 @@ class Json extends StdClass implements ArrayAccess, Iterator {
 	protected $jsonObject;
 	protected $iteratorKey;
 	protected $iteratorProperties;
+	protected $iteratorPropertyNames;
 
 	public function __construct($jsonObject) {
 		$this->jsonObject = $jsonObject;
-
 		$this->iteratorKey = 0;
+		$this->setPropertiesRecursive();
+	}
 
-		if(is_array($jsonObject)) {
-			$this->iteratorProperties = array_keys($jsonObject);
-		}
-		else {
-			$this->iteratorProperties = get_object_vars($jsonObject);
-		}
-
+	public function __toString():string {
+		return json_encode($this->jsonObject);
 	}
 
 	public function __get(string $key) {
@@ -35,17 +32,17 @@ class Json extends StdClass implements ArrayAccess, Iterator {
 
 	/** @link https://php.net/manual/en/arrayaccess.offsetget.php */
 	public function offsetGet($offset) {
-		return $this->jsonObject[$offset];
+		return $this->jsonObject->$offset;
 	}
 
 	/** @link https://php.net/manual/en/arrayaccess.offsetset.php */
 	public function offsetSet($offset, $value):void {
-		$this->jsonObject[$offset] = $value;
+		$this->jsonObject->$offset = $value;
 	}
 
 	/** @link https://php.net/manual/en/arrayaccess.offsetunset.php */
 	public function offsetUnset($offset):void {
-		unset($this->jsonObject[$offset]);
+		unset($this->jsonObject->$offset);
 	}
 
 	/** @link https://php.net/manual/en/iterator.current.php */
@@ -54,8 +51,8 @@ class Json extends StdClass implements ArrayAccess, Iterator {
 			return $this->jsonObject[$this->iteratorKey];
 		}
 
-		$property = $this->iteratorProperties[$this->iteratorKey];
-		return $this->jsonObject->{$property};
+		$property = $this->iteratorPropertyNames[$this->iteratorKey];
+		return $this->jsonObject->$property;
 	}
 
 	/** @link https://php.net/manual/en/iterator.next.php */
@@ -69,21 +66,38 @@ class Json extends StdClass implements ArrayAccess, Iterator {
 			return $this->iteratorKey;
 		}
 
-		return $this->iteratorProperties[$this->iteratorKey];
+		return $this->iteratorPropertyNames[$this->iteratorKey];
 	}
 
 	/** @link https://php.net/manual/en/iterator.valid.php */
-	public function valid() {
+	public function valid():bool {
+		if(!isset($this->iteratorPropertyNames[$this->iteratorKey])) {
+			return false;
+		}
+
+		$property = $this->iteratorPropertyNames[$this->iteratorKey];
 		if(is_array($this->jsonObject)) {
 			return isset($this->jsonObject[$this->iteratorKey]);
 		}
 
-		$property = $this->iteratorProperties[$this->iteratorKey];
 		return isset($this->jsonObject->{$property});
 	}
 
 	/** @link https://php.net/manual/en/iterator.rewind.php */
-	public function rewind() {
+	public function rewind():void {
 		$this->iteratorKey = 0;
+	}
+
+	private function setPropertiesRecursive():void {
+		foreach($this->jsonObject as $key => $value) {
+			if($value instanceof StdClass) {
+				$this->iteratorProperties[$key] = new self($value);
+			}
+			else {
+				$this->iteratorProperties[$key] = $value;
+			}
+
+			$this->iteratorPropertyNames []= $key;
+		}
 	}
 }

--- a/test/unit/Response/BodyResponseTest.php
+++ b/test/unit/Response/BodyResponseTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Gt\Fetch\Test;
+namespace Gt\Fetch\Test\Response;
 
 use Gt\Curl\Curl;
 use Gt\Curl\JsonDecodeException;
@@ -11,7 +11,7 @@ use Psr\Http\Message\StreamInterface;
 use React\EventLoop\LoopInterface;
 use RuntimeException;
 use SplFixedArray;
-use stdClass;
+use StdClass;
 
 class BodyResponseTest extends TestCase {
 	public function testText() {

--- a/test/unit/Response/JsonTest.php
+++ b/test/unit/Response/JsonTest.php
@@ -1,0 +1,53 @@
+<?php
+namespace Gt\Fetch\Test\Response;
+
+use Gt\Fetch\Response\Json;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class JsonTest extends TestCase {
+	public function testGetterSimple() {
+		$simple = new StdClass();
+		$simple->name = "Mark";
+		$simple->company = "Facebook";
+
+		$sut = new Json($simple);
+		self::assertEquals($simple->name, $sut->name);
+		self::assertEquals($simple->company, $sut->company);
+	}
+
+	public function testArrayAccessSimple() {
+		$simple = new StdClass();
+		$simple->name = "Marissa";
+		$simple->company = "Yahoo";
+
+		$sut = new Json($simple);
+		self::assertEquals($simple->name, $sut["name"]);
+		self::assertEquals($simple->company, $sut["company"]);
+	}
+
+	public function testToStringSimple() {
+		$simple = new StdClass();
+		$simple->name = "Sundar";
+		$simple->company = "Google";
+
+		$sut = new Json($simple);
+		self::assertEquals(json_encode($simple), (string)$sut);
+	}
+
+	public function testIteratorSimple() {
+		$simple = new StdClass();
+		$simple->name = "Satya";
+		$simple->company = "Microsoft";
+
+		$sut = new Json($simple);
+		$i = 0;
+		foreach($sut as $key => $value) {
+			$i++;
+			self::assertEquals($simple->$key, $value);
+		}
+
+
+		self::assertEquals(count(get_object_vars($simple)), $i);
+	}
+}

--- a/test/unit/Response/JsonTest.php
+++ b/test/unit/Response/JsonTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Gt\Fetch\Test\Response;
 
+use Gt\Fetch\Response\ImmutableObjectModificationException;
 use Gt\Fetch\Response\Json;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -14,6 +15,23 @@ class JsonTest extends TestCase {
 		$sut = new Json($simple);
 		self::assertEquals($simple->name, $sut->name);
 		self::assertEquals($simple->company, $sut->company);
+	}
+
+	public function testGetterNested() {
+		$nested = new StdClass();
+		$nested->name = new StdClass();
+		$nested->name->first = "Margaret";
+		$nested->name->last = "Hamilton";
+		$nested->job = new StdClass();
+		$nested->job->company = "MIT";
+		$nested->job->title = "Systems Engineer";
+
+		$sut = new Json($nested);
+		self::assertInstanceOf(Json::class, $sut->name);
+		self::assertEquals($nested->name->first, $sut->name->first);
+		self::assertEquals($nested->name->last, $sut->name->last);
+		self::assertEquals($nested->job->company, $sut->job->company);
+		self::assertEquals($nested->job->title, $sut->job->title);
 	}
 
 	public function testArrayAccessSimple() {
@@ -74,5 +92,34 @@ class JsonTest extends TestCase {
 			self::assertEquals($array[$i], $value);
 		}
 		self::assertEquals(count($array) - 1, $i);
+	}
+
+	public function testAssocArray() {
+		$sut = new Json([
+			"name" => "Katherine",
+			"employer" => "NASA",
+		]);
+		self::assertEquals("Katherine", $sut->name);
+		self::assertEquals("NASA", $sut->employer);
+	}
+
+	public function testIsset() {
+		$obj = new StdClass();
+		$obj->name = "Simon";
+		$sut = new Json($obj);
+		self::assertTrue(isset($obj->name));
+		self::assertFalse(isset($obj->age));
+	}
+
+	public function testSet() {
+		$sut = new Json(["example"]);
+		self::expectException(ImmutableObjectModificationException::class);
+		$sut->name = "Test";
+	}
+
+	public function testUnset() {
+		$sut = new Json(["example"]);
+		self::expectException(ImmutableObjectModificationException::class);
+		unset($sut->name);
 	}
 }

--- a/test/unit/Response/JsonTest.php
+++ b/test/unit/Response/JsonTest.php
@@ -26,6 +26,15 @@ class JsonTest extends TestCase {
 		self::assertEquals($simple->company, $sut["company"]);
 	}
 
+	public function testArrayAccessArray() {
+		$array = ["Bread", "Beans", "Milk", "Coffee"];
+		$sut = new Json($array);
+
+		foreach($array as $i => $value) {
+			self::assertEquals($value, $sut[$i]);
+		}
+	}
+
 	public function testToStringSimple() {
 		$simple = new StdClass();
 		$simple->name = "Sundar";
@@ -33,6 +42,12 @@ class JsonTest extends TestCase {
 
 		$sut = new Json($simple);
 		self::assertEquals(json_encode($simple), (string)$sut);
+	}
+
+	public function testToStringArray() {
+		$array = ["Bread", "Beans", "Milk", "Coffee"];
+		$sut = new Json($array);
+		self::assertEquals(json_encode($array), (string)$sut);
 	}
 
 	public function testIteratorSimple() {
@@ -49,5 +64,15 @@ class JsonTest extends TestCase {
 
 
 		self::assertEquals(count(get_object_vars($simple)), $i);
+	}
+
+	public function testIteratorArray() {
+		$array = ["Bread", "Beans", "Milk", "Coffee"];
+		$sut = new Json($array);
+
+		foreach($sut as $i => $value) {
+			self::assertEquals($array[$i], $value);
+		}
+		self::assertEquals(count($array) - 1, $i);
 	}
 }

--- a/test/unit/Response/JsonTest.php
+++ b/test/unit/Response/JsonTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Gt\Fetch\Test\Response;
 
+use DateTime;
 use Gt\Fetch\Response\ImmutableObjectModificationException;
 use Gt\Fetch\Response\Json;
 use PHPUnit\Framework\TestCase;
@@ -121,5 +122,31 @@ class JsonTest extends TestCase {
 		$sut = new Json(["example"]);
 		self::expectException(ImmutableObjectModificationException::class);
 		unset($sut->name);
+	}
+
+	public function testGetMissing() {
+		$sut = new Json(["name" => "nothing"]);
+		self::assertNull($sut->thisDoesNotExist);
+	}
+
+	public function testGetTypeSafe() {
+		$obj = new StdClass();
+		$obj->boolean = true;
+		$obj->integer = 123;
+		$obj->string = "Hello!";
+		$obj->floatingPoint = 123.456;
+		$obj->timeString = "2019-11-05 11:22:33";
+		$sut = new Json($obj);
+
+		self::assertIsBool($sut->getBool("boolean"));
+		self::assertEquals($obj->boolean, $sut->getBool("boolean"));
+		self::assertIsInt($sut->getInt("integer"));
+		self::assertEquals($obj->integer, $sut->getInt("integer"));
+		self::assertIsString($sut->getString("string"));
+		self::assertEquals($obj->string, $sut->getString("string"));
+		self::assertIsFloat($sut->getFloat("floatingPoint"));
+		self::assertEquals($obj->floatingPoint, $sut->getFloat("floatingPoint"));
+		self::assertInstanceOf(DateTime::class, $sut->getDateTime("timeString"));
+		self::assertEquals($obj->timeString, $sut->getDateTime("timeString")->format("Y-m-d H:i:s"));
 	}
 }


### PR DESCRIPTION
Working with JSON objects is a common use case for Fetch. This PR includes some useful functionality for working with JSON responses returned with `BodyResponse::json()`.

+ toString the object, or any of its nested properties to obtain the original JSON string.
+ Use type-safe getters `getInt`, `getDateTime`, etc. as with other PHP.Gt repositories.
+ Iterate over properties as you would expect.

All of the above works on nested properties of objects, as the Json object recursively builds references to itself.