### PR TITLE
Gt->GT rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           name: build-artifact-${{ matrix.php }}
           path: /tmp/github-actions
+          retention-days: 1
 
   phpunit:
     runs-on: ubuntu-latest
@@ -73,6 +74,7 @@ jobs:
         with:
           name: code-coverage-${{ matrix.php }}-${{ github.run_number }}
           path: _coverage
+          retention-days: 1
 
   coverage:
     runs-on: ubuntu-latest
@@ -167,21 +169,3 @@ jobs:
           php_version: ${{ matrix.php }}
           path: src/
           standard: phpcs.xml
-
-  remove_old_artifacts:
-    runs-on: ubuntu-latest
-
-    permissions:
-      actions: write
-
-    steps:
-      - name: Remove old artifacts for prior workflow runs on this repository
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api "/repos/${{ github.repository }}/actions/artifacts" | jq ".artifacts[] | select(.name | startswith(\"build-artifact\")) | .id" > artifact-id-list.txt
-          while read id
-          do
-            echo -n "Deleting artifact ID $id ... "
-            gh api --method DELETE /repos/${{ github.repository }}/actions/artifacts/$id && echo "Done"
-          done <artifact-id-list.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,25 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
 
 permissions:
   contents: read
   actions: read
-  id-token: none
 
 jobs:
   composer:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 8.4 ]
+        php: [ 8.4, 8.5 ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/composer-cache
           key: ${{ runner.os }}-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
@@ -27,6 +28,7 @@ jobs:
         uses: php-actions/composer@v6
         with:
           php_version: ${{ matrix.php }}
+          php_extensions: pcntl
 
       - name: Archive build
         run: mkdir /tmp/github-actions/ && tar --exclude=".git" -cvf /tmp/github-actions/build.tar ./
@@ -42,7 +44,7 @@ jobs:
     needs: [ composer ]
     strategy:
       matrix:
-        php: [ 8.4 ]
+        php: [ 8.4, 8.5 ]
 
     outputs:
       coverage: ${{ steps.store-coverage.outputs.coverage_text }}
@@ -77,7 +79,7 @@ jobs:
     needs: [ phpunit ]
     strategy:
       matrix:
-        php: [ 8.4 ]
+        php: [ 8.4, 8.5 ]
 
     steps:
       - uses: actions/checkout@v4
@@ -92,13 +94,15 @@ jobs:
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   phpstan:
     runs-on: ubuntu-latest
     needs: [ composer ]
     strategy:
       matrix:
-        php: [ 8.4 ]
+        php: [ 8.4, 8.5 ]
 
     steps:
       - uses: actions/download-artifact@v4
@@ -114,13 +118,15 @@ jobs:
         with:
           php_version: ${{ matrix.php }}
           path: src/
+          level: 6
+          memory_limit: 256M
 
   phpmd:
     runs-on: ubuntu-latest
     needs: [ composer ]
     strategy:
       matrix:
-        php: [ 8.4 ]
+        php: [ 8.4, 8.5 ]
 
     steps:
       - uses: actions/download-artifact@v4
@@ -144,7 +150,7 @@ jobs:
     needs: [ composer ]
     strategy:
       matrix:
-        php: [ 8.4 ]
+        php: [ 8.4, 8.5 ]
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /vendor
 /test/unit/_coverage
 /.idea
-# Local wiki symlink
-docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /vendor
 /test/unit/_coverage
 /.idea
+# Local wiki symlink
+docs

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See also, the [JavaScript implementation][fetch-js] that ships as standard in al
 
 ```php
 <?php
-$http = new Gt\Fetch\Http();
+$http = new GT\Fetch\Http();
 
 // Rather than creating the request now, `fetch` returns a Promise, 
 // for later resolution with the BodyResponse.

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "MIT",
 
 	"require": {
-		"php": ">=8.3",
+		"php": ">=8.4",
 		"ext-curl": "*",
 		"ext-json": "*",
 		"phpgt/async": "^1.0",
@@ -25,13 +25,14 @@
 
 	"autoload": {
 		"psr-4": {
+			"GT\\Fetch\\": "./src",
 			"Gt\\Fetch\\": "./src"
 		}
 	},
 
 	"autoload-dev": {
 		"psr-4": {
-			"Gt\\Fetch\\Test\\": "./test/phpunit"
+			"GT\\Fetch\\Test\\": "./test/phpunit"
 		}
 	},
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,10 @@
 		"psr-4": {
 			"GT\\Fetch\\": "./src",
 			"Gt\\Fetch\\": "./src"
-		}
+		},
+		"files": [
+			"namespace-aliases.php"
+		]
 	},
 
 	"autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e01ace85ce8c99fcd4e6f537db3c10a",
+    "content-hash": "e96acd272f8bf8eeeebe0df93b8b6140",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.6.3",
+            "version": "v6.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "134e98916fa2f663afa623970af345cd788e8967"
+                "reference": "6fea66c7204683af437864e7c4e7abf383d14bc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/134e98916fa2f663afa623970af345cd788e8967",
-                "reference": "134e98916fa2f663afa623970af345cd788e8967",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/6fea66c7204683af437864e7c4e7abf383d14bc0",
+                "reference": "6fea66c7204683af437864e7c4e7abf383d14bc0",
                 "shasum": ""
             },
             "require": {
@@ -77,9 +77,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.6.3"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/v6.7.2"
             },
-            "time": "2025-12-02T10:21:33+00:00"
+            "time": "2026-02-15T15:06:22+00:00"
         },
         {
             "name": "marc-mabe/php-enum",
@@ -319,16 +319,16 @@
         },
         {
             "name": "phpgt/http",
-            "version": "v1.3.6",
+            "version": "v1.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpgt/Http.git",
-                "reference": "0c9a10d190c2adbaaf4b7d7301258c90071bcdcc"
+                "reference": "7c92bd2d0c7b9d68aa29c39f01ce41a7fcb221ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpgt/Http/zipball/0c9a10d190c2adbaaf4b7d7301258c90071bcdcc",
-                "reference": "0c9a10d190c2adbaaf4b7d7301258c90071bcdcc",
+                "url": "https://api.github.com/repos/phpgt/Http/zipball/7c92bd2d0c7b9d68aa29c39f01ce41a7fcb221ee",
+                "reference": "7c92bd2d0c7b9d68aa29c39f01ce41a7fcb221ee",
                 "shasum": ""
             },
             "require": {
@@ -370,7 +370,7 @@
             "description": "PSR-7 HTTP message implementation.",
             "support": {
                 "issues": "https://github.com/phpgt/Http/issues",
-                "source": "https://github.com/phpgt/Http/tree/v1.3.6"
+                "source": "https://github.com/phpgt/Http/tree/v1.3.7"
             },
             "funding": [
                 {
@@ -378,7 +378,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-09T23:08:23+00:00"
+            "time": "2026-03-06T13:08:42+00:00"
         },
         {
             "name": "phpgt/input",
@@ -594,16 +594,16 @@
         },
         {
             "name": "phpgt/typesafegetter",
-            "version": "v1.3.2",
+            "version": "v1.3.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PhpGt/TypeSafeGetter.git",
-                "reference": "f760c05a37b1cc188dcbf800c5fdfab8a926b4b0"
+                "url": "https://github.com/phpgt/TypeSafeGetter.git",
+                "reference": "a0d339103828791989cbb81f760d252f3c2f8b8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PhpGt/TypeSafeGetter/zipball/f760c05a37b1cc188dcbf800c5fdfab8a926b4b0",
-                "reference": "f760c05a37b1cc188dcbf800c5fdfab8a926b4b0",
+                "url": "https://api.github.com/repos/phpgt/TypeSafeGetter/zipball/a0d339103828791989cbb81f760d252f3c2f8b8c",
+                "reference": "a0d339103828791989cbb81f760d252f3c2f8b8c",
                 "shasum": ""
             },
             "require": {
@@ -633,8 +633,8 @@
             ],
             "description": "An interface for objects that expose type-safe getter methods.",
             "support": {
-                "issues": "https://github.com/PhpGt/TypeSafeGetter/issues",
-                "source": "https://github.com/PhpGt/TypeSafeGetter/tree/v1.3.2"
+                "issues": "https://github.com/phpgt/TypeSafeGetter/issues",
+                "source": "https://github.com/phpgt/TypeSafeGetter/tree/v1.3.3"
             },
             "funding": [
                 {
@@ -642,7 +642,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-28T14:42:27+00:00"
+            "time": "2026-03-10T22:28:01+00:00"
         },
         {
             "name": "psr/http-message",
@@ -1284,11 +1284,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.32",
+            "version": "1.12.33",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2770dcdf5078d0b0d53f94317e06affe88419aa8",
-                "reference": "2770dcdf5078d0b0d53f94317e06affe88419aa8",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
                 "shasum": ""
             },
             "require": {
@@ -1333,7 +1333,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-30T10:16:31+00:00"
+            "time": "2026-02-28T20:30:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1658,16 +1658,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.60",
+            "version": "10.5.63",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f2e26f52f80ef77832e359205f216eeac00e320c"
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f2e26f52f80ef77832e359205f216eeac00e320c",
-                "reference": "f2e26f52f80ef77832e359205f216eeac00e320c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/33198268dad71e926626b618f3ec3966661e4d90",
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90",
                 "shasum": ""
             },
             "require": {
@@ -1688,7 +1688,7 @@
                 "phpunit/php-timer": "^6.0.0",
                 "sebastian/cli-parser": "^2.0.1",
                 "sebastian/code-unit": "^2.0.0",
-                "sebastian/comparator": "^5.0.4",
+                "sebastian/comparator": "^5.0.5",
                 "sebastian/diff": "^5.1.1",
                 "sebastian/environment": "^6.1.0",
                 "sebastian/exporter": "^5.1.4",
@@ -1739,7 +1739,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.60"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.63"
             },
             "funding": [
                 {
@@ -1763,7 +1763,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-06T07:50:42+00:00"
+            "time": "2026-01-27T05:48:37+00:00"
         },
         {
             "name": "psr/container",
@@ -2038,16 +2038,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.4",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e"
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e8e53097718d2b53cfb2aa859b06a41abf58c62e",
-                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
                 "shasum": ""
             },
             "require": {
@@ -2103,7 +2103,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.4"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
             },
             "funding": [
                 {
@@ -2123,7 +2123,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-07T05:25:07+00:00"
+            "time": "2026-01-24T09:25:16+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -2902,16 +2902,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v7.4.1",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "2c323304c354a43a48b61c5fa760fc4ed60ce495"
+                "reference": "6c17162555bfb58957a55bb0e43e00035b6ae3d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/2c323304c354a43a48b61c5fa760fc4ed60ce495",
-                "reference": "2c323304c354a43a48b61c5fa760fc4ed60ce495",
+                "url": "https://api.github.com/repos/symfony/config/zipball/6c17162555bfb58957a55bb0e43e00035b6ae3d5",
+                "reference": "6c17162555bfb58957a55bb0e43e00035b6ae3d5",
                 "shasum": ""
             },
             "require": {
@@ -2957,7 +2957,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.1"
+                "source": "https://github.com/symfony/config/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -2977,20 +2977,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T07:52:08+00:00"
+            "time": "2026-03-06T10:41:14+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.2",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "baf614f7c15b30ba6762d4b1ddabdf83dbf0d29b"
+                "reference": "0f651e58f4917fb0e2cd261ccbfe3d71e6e0f5db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/baf614f7c15b30ba6762d4b1ddabdf83dbf0d29b",
-                "reference": "baf614f7c15b30ba6762d4b1ddabdf83dbf0d29b",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/0f651e58f4917fb0e2cd261ccbfe3d71e6e0f5db",
+                "reference": "0f651e58f4917fb0e2cd261ccbfe3d71e6e0f5db",
                 "shasum": ""
             },
             "require": {
@@ -3041,7 +3041,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.2"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -3061,7 +3061,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-08T06:57:04+00:00"
+            "time": "2026-03-03T07:48:48+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3132,16 +3132,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.0",
+            "version": "v7.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d551b38811096d0be9c4691d406991b47c0c630a"
+                "reference": "3ebc794fa5315e59fd122561623c2e2e4280538e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d551b38811096d0be9c4691d406991b47c0c630a",
-                "reference": "d551b38811096d0be9c4691d406991b47c0c630a",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3ebc794fa5315e59fd122561623c2e2e4280538e",
+                "reference": "3ebc794fa5315e59fd122561623c2e2e4280538e",
                 "shasum": ""
             },
             "require": {
@@ -3178,7 +3178,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.0"
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.6"
             },
             "funding": [
                 {
@@ -3198,7 +3198,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-27T13:27:24+00:00"
+            "time": "2026-02-25T16:50:00+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3592,7 +3592,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.3",
+        "php": ">=8.4",
         "ext-curl": "*",
         "ext-json": "*"
     },

--- a/example/01-basic-fetch.php
+++ b/example/01-basic-fetch.php
@@ -1,10 +1,10 @@
 <?php
 require(implode(DIRECTORY_SEPARATOR, ["..", "vendor", "autoload.php"]));
 
-use Gt\Fetch\Http;
-use Gt\Http\Response;
-use Gt\Json\JsonKvpObject;
-use Gt\Json\JsonPrimitive\JsonArrayPrimitive;
+use GT\Fetch\Http;
+use GT\Http\Response;
+use GT\Json\JsonKvpObject;
+use GT\Json\JsonPrimitive\JsonArrayPrimitive;
 
 $http = new Http();
 

--- a/example/02-post-request.php
+++ b/example/02-post-request.php
@@ -23,9 +23,6 @@ $http->fetch("https://postman-echo.com/post", [
 // All of the request parameters can be passed directly here, or alternatively
 // the fetch() function can take a PSR-7 RequestInterface object.
 	"method" => "POST",
-	"headers" => [
-		"Content-Type" => "application/x-www-form-urlencoded",
-	],
 	"body" => $formData,
 ])
 	->then(function(Response $response) {

--- a/example/02-post-request.php
+++ b/example/02-post-request.php
@@ -1,10 +1,10 @@
 <?php
 require(implode(DIRECTORY_SEPARATOR, ["..", "vendor", "autoload.php"]));
 
-use Gt\Fetch\Http;
-use Gt\Http\FormData;
-use Gt\Http\Response;
-use Gt\Json\JsonObject;
+use GT\Fetch\Http;
+use GT\Http\FormData;
+use GT\Http\Response;
+use GT\Json\JsonObject;
 
 /*
  * This example uses postman-echo.com do test the request/response.

--- a/example/03-download-jpg.php
+++ b/example/03-download-jpg.php
@@ -1,9 +1,9 @@
 <?php
 require(implode(DIRECTORY_SEPARATOR, ["..", "vendor", "autoload.php"]));
 
-use Gt\Fetch\Http;
-use Gt\Http\Blob;
-use Gt\Http\Response;
+use GT\Fetch\Http;
+use GT\Http\Blob;
+use GT\Http\Response;
 
 /*
  * This example uses Cat-as-a-Service API to request a random photo of a cat.

--- a/example/04-multiple-concurrent-fetch.php
+++ b/example/04-multiple-concurrent-fetch.php
@@ -1,11 +1,11 @@
 <?php
 require(implode(DIRECTORY_SEPARATOR, ["..", "vendor", "autoload.php"]));
 
-use Gt\Fetch\Http;
-use Gt\Http\Blob;
-use Gt\Http\Response;
-use Gt\Json\JsonKvpObject;
-use Gt\Json\JsonPrimitive\JsonArrayPrimitive;
+use GT\Fetch\Http;
+use GT\Http\Blob;
+use GT\Http\Response;
+use GT\Json\JsonKvpObject;
+use GT\Json\JsonPrimitive\JsonArrayPrimitive;
 
 $getJsonFromResponse = function(Response $response) {
 	if(!$response->ok) {

--- a/example/05-upload-file.php
+++ b/example/05-upload-file.php
@@ -1,10 +1,10 @@
 <?php
 require(implode(DIRECTORY_SEPARATOR, ["..", "vendor", "autoload.php"]));
 
-use Gt\Fetch\Http;
-use Gt\Http\FormData;
-use Gt\Http\Response;
-use Gt\Json\JsonObject;
+use GT\Fetch\Http;
+use GT\Http\FormData;
+use GT\Http\Response;
+use GT\Json\JsonObject;
 
 $formData = new FormData();
 $formData->set("upload", new SplFileObject(__FILE__));

--- a/namespace-aliases.php
+++ b/namespace-aliases.php
@@ -1,0 +1,38 @@
+<?php
+
+$aliasList = [
+	"Gt\\Async\\Loop" => "GT\\Async\\Loop",
+	"Gt\\Async\\Timer\\PeriodicTimer" => "GT\\Async\\Timer\\PeriodicTimer",
+	"Gt\\Async\\Timer\\Timer" => "GT\\Async\\Timer\\Timer",
+	"Gt\\Curl\\Curl" => "GT\\Curl\\Curl",
+	"Gt\\Curl\\CurlException" => "GT\\Curl\\CurlException",
+	"Gt\\Curl\\CurlInterface" => "GT\\Curl\\CurlInterface",
+	"Gt\\Curl\\CurlMulti" => "GT\\Curl\\CurlMulti",
+	"Gt\\Curl\\CurlMultiInterface" => "GT\\Curl\\CurlMultiInterface",
+	"Gt\\Http\\Blob" => "GT\\Http\\Blob",
+	"Gt\\Http\\File" => "GT\\Http\\File",
+	"Gt\\Http\\FormData" => "GT\\Http\\FormData",
+	"Gt\\Http\\Header\\Parser" => "GT\\Http\\Header\\Parser",
+	"Gt\\Http\\Header\\RequestHeaders" => "GT\\Http\\Header\\RequestHeaders",
+	"Gt\\Http\\Request" => "GT\\Http\\Request",
+	"Gt\\Http\\RequestMethod" => "GT\\Http\\RequestMethod",
+	"Gt\\Http\\Response" => "GT\\Http\\Response",
+	"Gt\\Http\\Uri" => "GT\\Http\\Uri",
+	"Gt\\Json\\JsonKvpObject" => "GT\\Json\\JsonKvpObject",
+	"Gt\\Json\\JsonObject" => "GT\\Json\\JsonObject",
+	"Gt\\Json\\JsonPrimitive\\JsonArrayPrimitive" => "GT\\Json\\JsonPrimitive\\JsonArrayPrimitive",
+	"Gt\\Promise\\Deferred" => "GT\\Promise\\Deferred",
+	"Gt\\Promise\\Promise" => "GT\\Promise\\Promise",
+	"Gt\\Promise\\PromiseInterface" => "GT\\Promise\\PromiseInterface",
+];
+
+foreach($aliasList as $old => $new) {
+	$oldExists = class_exists($old)
+		|| interface_exists($old)
+		|| trait_exists($old)
+		|| function_exists("enum_exists") && enum_exists($old);
+
+	if($oldExists && !class_exists($new) && !interface_exists($new) && !trait_exists($new)) {
+		class_alias($old, $new);
+	}
+}

--- a/src/AbortController.php
+++ b/src/AbortController.php
@@ -1,5 +1,5 @@
 <?php
-namespace Gt\Fetch;
+namespace GT\Fetch;
 
 class AbortController extends Controller {
 	public self $signal;

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -1,4 +1,4 @@
 <?php
-namespace Gt\Fetch;
+namespace GT\Fetch;
 
 abstract class Controller {}

--- a/src/CurlOptBuilder.php
+++ b/src/CurlOptBuilder.php
@@ -1,10 +1,10 @@
 <?php
-namespace Gt\Fetch;
+namespace GT\Fetch;
 
 use CURLFile;
-use Gt\Http\File;
-use Gt\Http\FormData;
-use Gt\Http\RequestMethod;
+use GT\Http\File;
+use GT\Http\FormData;
+use GT\Http\RequestMethod;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 

--- a/src/FetchException.php
+++ b/src/FetchException.php
@@ -1,5 +1,5 @@
 <?php
-namespace Gt\Fetch;
+namespace GT\Fetch;
 
 use RuntimeException;
 

--- a/src/Http.php
+++ b/src/Http.php
@@ -1,17 +1,17 @@
 <?php
-namespace Gt\Fetch;
+namespace GT\Fetch;
 
-use Gt\Async\Loop;
-use Gt\Async\Timer\PeriodicTimer;
-use Gt\Async\Timer\Timer;
-use Gt\Curl\Curl;
-use Gt\Curl\CurlMulti;
-use Gt\Fetch\Response\FetchResponse;
-use Gt\Http\Response;
-use Gt\Http\Uri;
-use Gt\Promise\Deferred;
-use Gt\Promise\Promise;
-use Gt\Promise\PromiseInterface;
+use GT\Async\Loop;
+use GT\Async\Timer\PeriodicTimer;
+use GT\Async\Timer\Timer;
+use GT\Curl\Curl;
+use GT\Curl\CurlMulti;
+use GT\Fetch\Response\FetchResponse;
+use GT\Http\Response;
+use GT\Http\Uri;
+use GT\Promise\Deferred;
+use GT\Promise\Promise;
+use GT\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;

--- a/src/NotAvailableServerSideException.php
+++ b/src/NotAvailableServerSideException.php
@@ -1,4 +1,4 @@
 <?php
-namespace Gt\Fetch;
+namespace GT\Fetch;
 
 class NotAvailableServerSideException extends FetchException {}

--- a/src/RequestResolver.php
+++ b/src/RequestResolver.php
@@ -1,14 +1,14 @@
 <?php
-namespace Gt\Fetch;
+namespace GT\Fetch;
 
 use CurlHandle;
-use Gt\Async\Loop;
-use Gt\Curl\CurlException;
-use Gt\Curl\CurlInterface;
-use Gt\Curl\CurlMultiInterface;
-use Gt\Http\Header\Parser;
-use Gt\Http\Response;
-use Gt\Promise\Deferred;
+use GT\Async\Loop;
+use GT\Curl\CurlException;
+use GT\Curl\CurlInterface;
+use GT\Curl\CurlMultiInterface;
+use GT\Http\Header\Parser;
+use GT\Http\Response;
+use GT\Promise\Deferred;
 use Psr\Http\Message\UriInterface;
 
 class RequestResolver {

--- a/src/UnknownCurlOptException.php
+++ b/src/UnknownCurlOptException.php
@@ -1,4 +1,4 @@
 <?php
-namespace Gt\Fetch;
+namespace GT\Fetch;
 
 class UnknownCurlOptException extends FetchException {}

--- a/test/phpunit/CurlOptBuilderTest.php
+++ b/test/phpunit/CurlOptBuilderTest.php
@@ -1,10 +1,10 @@
 <?php
-namespace Gt\Fetch\Test;
+namespace GT\Fetch\Test;
 
-use Gt\Fetch\AbortController;
-use Gt\Fetch\CurlOptBuilder;
-use Gt\Fetch\NotAvailableServerSideException;
-use Gt\Fetch\UnknownCurlOptException;
+use GT\Fetch\AbortController;
+use GT\Fetch\CurlOptBuilder;
+use GT\Fetch\NotAvailableServerSideException;
+use GT\Fetch\UnknownCurlOptException;
 use PHPUnit\Framework\TestCase;
 
 class CurlOptBuilderTest extends TestCase {

--- a/test/phpunit/Helper/ResponseSimulator.php
+++ b/test/phpunit/Helper/ResponseSimulator.php
@@ -1,7 +1,7 @@
 <?php
-namespace Gt\Fetch\Test\Helper;
+namespace GT\Fetch\Test\Helper;
 
-use Gt\Curl\Curl;
+use GT\Curl\Curl;
 
 class ResponseSimulator {
 	const RANDOM_BODY_WORDS = ["pursuit","forest","gravel","timber","wonder","eject","slogan","monkey","construct","earthquake","respect","publish","forward","circle","summer","define","highlight","refuse","salon","theater","lily","earwax","variant","account","resource"];

--- a/test/phpunit/Helper/TestCurl.php
+++ b/test/phpunit/Helper/TestCurl.php
@@ -1,7 +1,7 @@
 <?php
-namespace Gt\Fetch\Test\Helper;
+namespace GT\Fetch\Test\Helper;
 
-use Gt\Curl\Curl;
+use GT\Curl\Curl;
 
 class TestCurl extends Curl {
 	protected string $id;

--- a/test/phpunit/Helper/TestCurlMulti.php
+++ b/test/phpunit/Helper/TestCurlMulti.php
@@ -1,8 +1,8 @@
 <?php
-namespace Gt\Fetch\Test\Helper;
+namespace GT\Fetch\Test\Helper;
 
-use Gt\Curl\CurlInterface;
-use Gt\Curl\CurlMulti;
+use GT\Curl\CurlInterface;
+use GT\Curl\CurlMulti;
 
 class TestCurlMulti extends CurlMulti {
 	protected array $curlHandleArray;

--- a/test/phpunit/HttpTest.php
+++ b/test/phpunit/HttpTest.php
@@ -1,14 +1,14 @@
 <?php
-namespace Gt\Fetch\Test;
+namespace GT\Fetch\Test;
 
-use Gt\Fetch\FetchException;
-use Gt\Fetch\Http;
-use Gt\Fetch\Test\Helper\ResponseSimulator;
-use Gt\Fetch\Test\Helper\TestCurl;
-use Gt\Fetch\Test\Helper\TestCurlMulti;
-use Gt\Http\Request;
-use Gt\Http\Response;
-use Gt\Http\Uri;
+use GT\Fetch\FetchException;
+use GT\Fetch\Http;
+use GT\Fetch\Test\Helper\ResponseSimulator;
+use GT\Fetch\Test\Helper\TestCurl;
+use GT\Fetch\Test\Helper\TestCurlMulti;
+use GT\Http\Request;
+use GT\Http\Response;
+use GT\Http\Uri;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UriInterface;
 use Throwable;


### PR DESCRIPTION
To mark the v5 release of WebEngine, all namespace prefixes are being changed to GT for consistency.

This closes #162 