### PR TITLE
fix: redirect is checked on native handler

### DIFF
--- a/src/RequestResolver.php
+++ b/src/RequestResolver.php
@@ -24,6 +24,8 @@ class RequestResolver {
 	private array $headerList;
 	/** @var array<string|null> */
 	private array $integrityList;
+	/** @var array<int|null> */
+	private array $maxRedirectsList;
 	/** @var array<object|null> */
 	private array $signalList;
 
@@ -38,6 +40,7 @@ class RequestResolver {
 		$this->responseList = [];
 		$this->headerList = [];
 		$this->integrityList = [];
+		$this->maxRedirectsList = [];
 		$this->signalList = [];
 	}
 
@@ -92,6 +95,10 @@ class RequestResolver {
 		array_push($this->curlMultiList, $curlMulti);
 		array_push($this->deferredList, $deferred);
 		array_push($this->integrityList, $integrity);
+		array_push(
+			$this->maxRedirectsList,
+			$curlOptArray[CURLOPT_MAXREDIRS] ?? null
+		);
 		array_push($this->responseList, $bodyResponse);
 		array_push($this->headerList, "");
 		array_push($this->signalList, $signal);
@@ -198,7 +205,7 @@ class RequestResolver {
 		}
 
 		if(str_starts_with(strtolower($headerLine), "location: ")) {
-			if($ch->getInfo(CURLOPT_MAXREDIRS) === 0) {
+			if($this->maxRedirectsList[$i] === 0) {
 				throw new FetchException("Redirect is disallowed");
 			}
 		}

--- a/test/phpunit/Helper/NativeHandleTestCurl.php
+++ b/test/phpunit/Helper/NativeHandleTestCurl.php
@@ -1,0 +1,8 @@
+<?php
+namespace GT\Fetch\Test\Helper;
+
+class NativeHandleTestCurl extends TestCurl {
+	public function getHandle() {
+		return $this->ch;
+	}
+}

--- a/test/phpunit/Helper/ResponseSimulator.php
+++ b/test/phpunit/Helper/ResponseSimulator.php
@@ -1,7 +1,7 @@
 <?php
 namespace GT\Fetch\Test\Helper;
 
-use GT\Curl\Curl;
+use GT\Curl\CurlInterface;
 
 class ResponseSimulator {
 	const RANDOM_BODY_WORDS = ["pursuit","forest","gravel","timber","wonder","eject","slogan","monkey","construct","earthquake","respect","publish","forward","circle","summer","define","highlight","refuse","salon","theater","lily","earwax","variant","account","resource"];
@@ -25,6 +25,7 @@ class ResponseSimulator {
 
 	static public function start() {
 		self::$started = true;
+		self::$redirectAdded = false;
 		self::$headerBuffer = self::generateHeaders();
 		self::$bodyBuffer = self::generateBody();
 	}
@@ -73,11 +74,11 @@ class ResponseSimulator {
 		return self::$started;
 	}
 
-	static public function sendChunk(Curl $ch):int {
+	static public function sendChunk(CurlInterface $ch):int {
 // TODO: If the URL is test://should-redirect, send the redirect header here
 		$url = $ch->getInfo(CURLINFO_EFFECTIVE_URL);
 		if($url === "test://should-redirect") {
-			$locationRedirect = "Location: /redirected";
+			$locationRedirect = "Location: /redirected\r\n";
 			if(!self::$redirectAdded) {
 				array_splice(self::$headerBuffer, 1, 0, $locationRedirect);
 				self::$redirectAdded = true;
@@ -88,7 +89,7 @@ class ResponseSimulator {
 
 			call_user_func(
 				self::$headerCallback,
-				$ch,
+				$ch->getHandle(),
 				$data
 			);
 
@@ -100,13 +101,14 @@ class ResponseSimulator {
 
 			call_user_func(
 				self::$bodyCallback,
-				$ch,
+				$ch->getHandle(),
 				$data
 			);
 
 			return 1;
 		}
 		else {
+			self::$started = false;
 			return 0;
 		}
 	}

--- a/test/phpunit/RequestResolverTest.php
+++ b/test/phpunit/RequestResolverTest.php
@@ -1,0 +1,46 @@
+<?php
+namespace GT\Fetch\Test;
+
+use GT\Fetch\FetchException;
+use GT\Fetch\RequestResolver;
+use GT\Fetch\Test\Helper\NativeHandleTestCurl;
+use GT\Fetch\Test\Helper\TestCurlMulti;
+use Gt\Async\Loop;
+use Gt\Http\Response;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
+
+class RequestResolverTest extends TestCase {
+	public function testWriteHeaderRejectsRedirectsForNativeCurlHandle():void {
+		$sut = new RequestResolver(
+			new Loop(),
+			NativeHandleTestCurl::class,
+			TestCurlMulti::class,
+		);
+		$curl = new NativeHandleTestCurl("test://should-redirect");
+		$response = new Response();
+		$response->startDeferredResponse($curl);
+
+		$this->setProperty($sut, "curlList", [$curl]);
+		$this->setProperty($sut, "responseList", [$response]);
+		$this->setProperty($sut, "headerList", [""]);
+		$this->setProperty($sut, "maxRedirectsList", [0]);
+		$this->setProperty($sut, "signalList", [null]);
+
+		$writeHeader = new ReflectionMethod($sut, "writeHeader");
+
+		self::expectException(FetchException::class);
+		self::expectExceptionMessage("Redirect is disallowed");
+		$writeHeader->invoke($sut, $curl->getHandle(), "Location: /redirected\r\n");
+	}
+
+	private function setProperty(
+		RequestResolver $requestResolver,
+		string $property,
+		array $value,
+	):void {
+		$reflectionProperty = new ReflectionProperty($requestResolver, $property);
+		$reflectionProperty->setValue($requestResolver, $value);
+	}
+}


### PR DESCRIPTION
This fix is to stop asking the callback argument for redirect configuration and instead use the redirect limit already known when the request is created.

`RequestResolver` now stores the configured `CURLOPT_MAXREDIRS` value alongside the rest of the request state and checks that stored value when it sees a `Location` header. 

That removes the dependency on whether the callback received a wrapper object or a native handle. 

The test coverage was updated to prove the native-handle case explicitly using `NativeHandleTestCurl`, which restores the production meaning of `getHandle()` for that test path while keeping the rest of the simulator behaviour unchanged.

closes #180